### PR TITLE
Fixed github workflow

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,5 +10,6 @@ pytest = "*"
 
 [packages]
 colorama = "*"
+importlib-metadata = "==1.7.0"
 
 [requires]


### PR DESCRIPTION
Adding `importlib-metadata` package to pipfile solves the import errors! 💯 