### PR TITLE
dev(hansbug): use chardet to support utf-8 characters

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,5 +39,5 @@ jobs:
         pipenv run mypy -p make_to_batch
     - name: Test with pytest
       run: |
-        pipenv run pip install .
-        pipenv run pytest
+        pipenv run pip install .[test]
+        pipenv run pytest -sv --cov-report term-missing --cov=./make_to_batch

--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,7 @@ cmake-build-*/
 
 # IntelliJ
 out/
+.idea/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/

--- a/make_to_batch/cli.py
+++ b/make_to_batch/cli.py
@@ -19,10 +19,11 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
-
 import argparse
 import locale
 import os
+import sys
+from typing import Optional, List
 
 import colorama
 
@@ -32,7 +33,7 @@ from make_to_batch.makefile import Makefile
 _DEFAULT_ENCODING = locale.getpreferredencoding(False)
 
 
-def setup_args():
+def setup_args(args: List[str]):
     """Set the tool's arguments.
 
     Returns
@@ -73,7 +74,7 @@ def setup_args():
         default=_DEFAULT_ENCODING,
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     if not os.path.exists(args.input):
         raise FileNotFoundError("The Makefile '{}' does not exists.".format(args.input))
@@ -81,15 +82,16 @@ def setup_args():
     return args
 
 
-def run():
+def run_with_args(args: Optional[List[str]] = None):
     """The main function.
 
     Run the tool.
     """
     colorama.init()
+    args = list(args or sys.argv[1:])
 
     try:
-        args = setup_args()
+        args = setup_args(args)
     except FileNotFoundError as e:
         print(colorama.Fore.RED + "ERROR: " + str(e) + colorama.Style.RESET_ALL)
         return
@@ -107,3 +109,7 @@ def run():
     # Create and write the output file
     with open(args.output, "w", encoding=encoding) as f:
         f.write(makefile.to_batch())
+
+
+def run():
+    return run_with_args(None)

--- a/make_to_batch/cli.py
+++ b/make_to_batch/cli.py
@@ -21,12 +21,15 @@
 #  SOFTWARE.
 
 import argparse
+import locale
 import os
 
 import colorama
 
 from make_to_batch import __version__
 from make_to_batch.makefile import Makefile
+
+_DEFAULT_ENCODING = locale.getpreferredencoding(False)
 
 
 def setup_args():
@@ -64,6 +67,11 @@ def setup_args():
         help="set the name of the output batch file. Defaults to './make.bat'",
         default='./make.bat'
     )
+    parser.add_argument(
+        '-e', '--encoding',
+        help="set the encoding of the input and output file. Defaults to %s" % (repr(_DEFAULT_ENCODING),),
+        default=_DEFAULT_ENCODING,
+    )
 
     args = parser.parse_args()
 
@@ -87,14 +95,15 @@ def run():
         return
 
     makefile = Makefile()
+    encoding = args.encoding
 
     # Read the content of the Makefile
-    with open(args.input, "r") as f:
+    with open(args.input, "r", encoding=encoding) as f:
         makefile.parse_file(f.read())
 
     # Create the output directories
     os.makedirs(os.path.dirname(args.output) or '.', exist_ok=True)
 
     # Create and write the output file
-    with open(args.output, "w") as f:
+    with open(args.output, "w", encoding=encoding) as f:
         f.write(makefile.to_batch())

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,12 @@ setup(
     install_requires=[
         "colorama",
     ],
+    extras_require={
+        'test': [
+            'pytest~=5.4.3',
+            'pytest-cov~=2.10.1',
+        ]
+    },
     entry_points={
         'console_scripts': [
             'make-to-batch = make_to_batch.cli:run',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,25 @@
+import pathlib
+import tempfile
+
+from make_to_batch.cli import run_with_args
+
+_SIMPLE_MAKEFILE = """
+print:
+\techo 'This is a line'
+"""
+
+
+class TestCli:
+    def test_simple_demo(self):
+        with tempfile.NamedTemporaryFile('w') as srcf:
+            pathlib.Path(srcf.name).write_text(_SIMPLE_MAKEFILE)
+
+            with tempfile.NamedTemporaryFile('r') as dstf:
+                run_with_args(['-i', srcf.name, '-o', dstf.name])
+
+                dst_text = pathlib.Path(dstf.name).read_text()
+                assert "IF /I \"%1\"==\"print\" GOTO print" in dst_text
+                assert 'GOTO error' in dst_text
+                
+                assert ":print" in dst_text
+                assert "echo 'This is a line'" in dst_text


### PR DESCRIPTION
PR of issue #8 .

BTW: Maybe you can try to use [click](https://github.com/pallets/click) as a CLI framework to quickly build and support unittest. There is a lack of unittest now, which will cause some confusion for contributors.